### PR TITLE
Disable OpenSSL engine headers when unavailable

### DIFF
--- a/plugins/imdtls/imdtls.c
+++ b/plugins/imdtls/imdtls.c
@@ -41,7 +41,9 @@
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined(LIBRESSL_VERSION_NUMBER)
 #	include <openssl/bioerr.h>
 #endif
-#include <openssl/engine.h>
+#ifndef OPENSSL_NO_ENGINE
+#       include <openssl/engine.h>
+#endif
 // ---
 
 #include "rsyslog.h"

--- a/plugins/omdtls/omdtls.c
+++ b/plugins/omdtls/omdtls.c
@@ -52,7 +52,9 @@
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined(LIBRESSL_VERSION_NUMBER)
 #	include <openssl/bioerr.h>
 #endif
-#include <openssl/engine.h>
+#ifndef OPENSSL_NO_ENGINE
+#       include <openssl/engine.h>
+#endif
 // ---
 
 // Include rsyslog headers

--- a/runtime/net_ossl.h
+++ b/runtime/net_ossl.h
@@ -31,7 +31,9 @@
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined(LIBRESSL_VERSION_NUMBER)
 #	include <openssl/bioerr.h>
 #endif
-#include <openssl/engine.h>
+#ifndef OPENSSL_NO_ENGINE
+#       include <openssl/engine.h>
+#endif
 #include <openssl/rand.h>
 #include <openssl/evp.h>
 

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -129,8 +129,10 @@
 #ifdef ENABLE_OPENSSL
 	#include <openssl/ssl.h>
 	#include <openssl/x509v3.h>
-	#include <openssl/err.h>
-	#include <openssl/engine.h>
+       #include <openssl/err.h>
+#       ifndef OPENSSL_NO_ENGINE
+#               include <openssl/engine.h>
+#       endif
 
 	/* OpenSSL API differences */
 	#if OPENSSL_VERSION_NUMBER >= 0x10100000L


### PR DESCRIPTION
## Summary
- avoid including `openssl/engine.h` when `OPENSSL_NO_ENGINE` is defined
- update DTLS modules and tcpflood test accordingly

## Testing
- `devtools/check-codestyle.sh runtime/net_ossl.h`
- `devtools/check-codestyle.sh plugins/imdtls/imdtls.c`
- `devtools/check-codestyle.sh plugins/omdtls/omdtls.c`
- `devtools/check-codestyle.sh tests/tcpflood.c`
- `./autogen.sh` *(fails: `autoreconf: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684a758e441083228ae1dd2a897e5468