### PR TITLE
Fix duplicate LDFLAGS assignments in AMQP1 plugins

### DIFF
--- a/contrib/omamqp1/Makefile.am
+++ b/contrib/omamqp1/Makefile.am
@@ -2,7 +2,6 @@ pkglib_LTLIBRARIES = omamqp1.la
 
 omamqp1_la_SOURCES = omamqp1.c
 if ENABLE_QPIDPROTON_STATIC
-omamqp1_la_LDFLAGS = -module -avoid-version $(PROTON_PROACTOR_LIBS) $(PTHREADS_LIBS) $(OPENSSL_LIBS) -lm
 omamqp1_la_LDFLAGS = -module -avoid-version -Wl,-whole-archive -l:libqpid-proton-proactor-static.a -l:libqpid-proton-core-static.a -Wl,--no-whole-archive $(PTHREADS_LIBS) $(OPENSSL_LIBS) ${RT_LIBS} -lsasl2
 omamqp1_la_LIBADD =
 else

--- a/plugins/omazureeventhubs/Makefile.am
+++ b/plugins/omazureeventhubs/Makefile.am
@@ -2,7 +2,6 @@ pkglib_LTLIBRARIES = omazureeventhubs.la
 
 omazureeventhubs_la_SOURCES = omazureeventhubs.c
 if ENABLE_QPIDPROTON_STATIC
-omazureeventhubs_la_LDFLAGS = -module -avoid-version $(PROTON_PROACTOR_LIBS) $(PTHREADS_LIBS) $(OPENSSL_LIBS) -lm
 omazureeventhubs_la_LDFLAGS = -module -avoid-version -Wl,-whole-archive -l:libqpid-proton-proactor-static.a -l:libqpid-proton-core-static.a -Wl,--no-whole-archive $(PTHREADS_LIBS) $(OPENSSL_LIBS) ${RT_LIBS} -lsasl2
 omazureeventhubs_la_LIBADD =
 else


### PR DESCRIPTION
## Summary
- remove redundant LDFLAGS lines from `contrib/omamqp1` and `plugins/omazureeventhubs`

## Testing
- `./devtools/check-codestyle.sh contrib/omamqp1/Makefile.am`
- `./devtools/check-codestyle.sh plugins/omazureeventhubs/Makefile.am`


------
https://chatgpt.com/codex/tasks/task_e_684a8e75563c8322a33cff68aef14b16